### PR TITLE
Sync edited timestamps with history and enable session deletion

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -85,34 +85,40 @@ export default function Home() {
   const handleBreastfeedingComplete = React.useCallback(() => {
     // For breastfeeding, always save the elapsed time (how long the session lasted)
     // regardless of whether the timer was in stopwatch or countdown mode
-    const elapsedTimeMs = breastfeedingTimer.mode === 'countdown' 
-      ? (breastfeedingTimer.initialTimeMs - breastfeedingTimer.timeMs) 
+    const elapsedTimeMs = breastfeedingTimer.mode === 'countdown'
+      ? (breastfeedingTimer.initialTimeMs - breastfeedingTimer.timeMs)
       : breastfeedingTimer.timeMs;
-    
-    sessionManager.completeBreastfeeding(elapsedTimeMs, notes);
+
+    sessionManager.completeBreastfeeding(elapsedTimeMs, notes, customSessionTime || undefined);
     breastfeedingTimer.reset();
     setNotes('');
+    setCustomSessionTime(null);
+    setCurrentTime(new Date());
     scripture.onTimerComplete();
-  }, [breastfeedingTimer, sessionManager, notes, scripture]);
+  }, [breastfeedingTimer, sessionManager, notes, scripture, customSessionTime]);
 
   const handleBottleFeedingRecord = React.useCallback(() => {
-    sessionManager.recordBottleFeeding(bottleAmount, bottleUnit, notes);
+    sessionManager.recordBottleFeeding(bottleAmount, bottleUnit, notes, customSessionTime || undefined);
     setBottleAmount('');
     setNotes('');
-  }, [sessionManager, bottleAmount, bottleUnit, notes]);
+    setCustomSessionTime(null);
+    setCurrentTime(new Date());
+  }, [sessionManager, bottleAmount, bottleUnit, notes, customSessionTime]);
 
   const handleSleepingComplete = React.useCallback(() => {
     // For sleeping, always save the elapsed time (how long the sleep session lasted)
     // regardless of whether the timer was in stopwatch or countdown mode
-    const elapsedTimeMs = sleepingTimer.mode === 'countdown' 
-      ? (sleepingTimer.initialTimeMs - sleepingTimer.timeMs) 
+    const elapsedTimeMs = sleepingTimer.mode === 'countdown'
+      ? (sleepingTimer.initialTimeMs - sleepingTimer.timeMs)
       : sleepingTimer.timeMs;
-    
-    sessionManager.completeSleeping(elapsedTimeMs, notes);
+
+    sessionManager.completeSleeping(elapsedTimeMs, notes, customSessionTime || undefined);
     sleepingTimer.reset();
     setNotes('');
     setSleepStartTime(null);
-  }, [sleepingTimer, sessionManager, notes]);
+    setCustomSessionTime(null);
+    setCurrentTime(new Date());
+  }, [sleepingTimer, sessionManager, notes, customSessionTime]);
 
   const handleSleepStart = React.useCallback(() => {
     setSleepStartTime(new Date());
@@ -295,7 +301,11 @@ export default function Home() {
         </div>
 
         {/* Recent Sessions */}
-        <SessionHistory sessions={sessionManager.sessions} activeTab={activeTab} />
+        <SessionHistory
+          sessions={sessionManager.sessions}
+          activeTab={activeTab}
+          onDeleteSessions={sessionManager.deleteSessions}
+        />
 
         {/* Encouragement Footer */}
         <motion.div

--- a/components/Session/SessionHistory.tsx
+++ b/components/Session/SessionHistory.tsx
@@ -10,12 +10,31 @@ import { ozToMl } from '../../utils/conversions';
 interface SessionHistoryProps {
   sessions: FeedingSession[];
   activeTab: SessionType;
+  onDeleteSessions?: (ids: string[]) => void;
 }
 
-export const SessionHistory = React.memo(({ sessions, activeTab }: SessionHistoryProps) => {
+export const SessionHistory = React.memo(({ sessions, activeTab, onDeleteSessions }: SessionHistoryProps) => {
   // Date range filter state
   type Range = '24h' | '3d' | '7d' | '30d' | 'all';
   const [range, setRange] = useState<Range>('24h');
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  const toggleSelect = (id: string) => {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  };
+
+  const handleDelete = () => {
+    if (onDeleteSessions && selected.size > 0) {
+      onDeleteSessions(Array.from(selected));
+      setSelected(new Set());
+      setSelectionMode(false);
+    }
+  };
 
   const filteredSessions = useMemo(() => {
     const byTab = sessions.filter(s => s.type === activeTab);
@@ -130,7 +149,31 @@ export const SessionHistory = React.memo(({ sessions, activeTab }: SessionHistor
           <Clock className="w-4 h-4 sm:w-5 sm:h-5" />
           Recent {tabNames[activeTab]} History
         </h3>
-        <div className="ml-auto">
+        <div className="ml-auto flex items-center gap-2">
+          {selectionMode && (
+            <button
+              onClick={handleDelete}
+              className="text-xs sm:text-sm px-2 py-1.5 bg-red-500 text-white rounded-full shadow-sm"
+            >
+              Delete
+            </button>
+          )}
+          {selectionMode && (
+            <button
+              onClick={() => { setSelectionMode(false); setSelected(new Set()); }}
+              className="text-xs sm:text-sm px-2 py-1.5 bg-gray-100 text-gray-700 rounded-full shadow-sm"
+            >
+              Cancel
+            </button>
+          )}
+          {!selectionMode && (
+            <button
+              onClick={() => setSelectionMode(true)}
+              className="text-xs sm:text-sm px-2 py-1.5 bg-gray-100 text-gray-700 rounded-full shadow-sm"
+            >
+              Select
+            </button>
+          )}
           <select
             value={range}
             onChange={(e) => setRange(e.target.value as Range)}
@@ -154,9 +197,17 @@ export const SessionHistory = React.memo(({ sessions, activeTab }: SessionHistor
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: index * 0.1 }}
-              className="flex items-center justify-between p-3 sm:p-4 bg-white rounded-lg shadow-sm border border-gray-100"
+              className={`flex items-center justify-between p-3 sm:p-4 rounded-lg shadow-sm border border-gray-100 ${selectionMode && selected.has(session.id) ? 'bg-gray-50' : 'bg-white'}`}
             >
               <div className="flex items-center gap-3 w-0 flex-1 min-w-0">
+                {selectionMode && (
+                  <input
+                    type="checkbox"
+                    checked={selected.has(session.id)}
+                    onChange={() => toggleSelect(session.id)}
+                    className="w-4 h-4 flex-shrink-0"
+                  />
+                )}
                 <div className={`p-2 rounded-full ${theme.secondary}`}>
                   {getSessionIcon(session.type as SessionType)}
                 </div>

--- a/hooks/useSessionManager.ts
+++ b/hooks/useSessionManager.ts
@@ -19,10 +19,11 @@ export interface UseSessionManagerReturn {
   loading: boolean;
   error: string | null;
   refreshSessions: () => Promise<void>;
-  completeBreastfeeding: (timerTimeMs: number, notes?: string) => void;
-  recordBottleFeeding: (amount: string, unit: 'ml' | 'oz', notes?: string) => void;
-  completeSleeping: (timerTimeMs: number, notes?: string) => void;
+  completeBreastfeeding: (timerTimeMs: number, notes?: string, endTimeOverride?: Date) => void;
+  recordBottleFeeding: (amount: string, unit: 'ml' | 'oz', notes?: string, timeOverride?: Date) => void;
+  completeSleeping: (timerTimeMs: number, notes?: string, endTimeOverride?: Date) => void;
   recordDiaperChange: (input: DiaperRecordInput) => void;
+  deleteSessions: (ids: string[]) => Promise<void>;
 }
 
 export function useSessionManager(): UseSessionManagerReturn {
@@ -126,20 +127,20 @@ export function useSessionManager(): UseSessionManagerReturn {
     }
   }, []);
 
-  const completeBreastfeeding = useCallback(async (timerTimeMs: number, notes?: string) => {
+  const completeBreastfeeding = useCallback(async (timerTimeMs: number, notes?: string, endTimeOverride?: Date) => {
     if (timerTimeMs === 0) return;
 
     try {
-      const now = new Date();
+      const endTime = endTimeOverride ?? new Date();
       const durationSeconds = Math.floor(timerTimeMs / 1000);
-      const startTime = new Date(now.getTime() - timerTimeMs);
+      const startTime = new Date(endTime.getTime() - timerTimeMs);
 
       if (!isAuthed) {
         const local: BreastfeedingSession = {
           id: String(Date.now()),
           type: 'breastfeeding',
           startTime,
-          endTime: now,
+          endTime,
           date: startTime.toISOString().split('T')[0],
           duration: durationSeconds,
           notes: notes || undefined,
@@ -158,7 +159,7 @@ export function useSessionManager(): UseSessionManagerReturn {
           body: JSON.stringify({
             sessionType: 'breastfeeding',
             startTime: startTime.toISOString(),
-            endTime: now.toISOString(),
+            endTime: endTime.toISOString(),
             duration: durationSeconds,
             notes: notes || null,
           }),
@@ -188,12 +189,12 @@ export function useSessionManager(): UseSessionManagerReturn {
     }
   }, [basePath, isAuthed, saveLocal, mapApiToSession]);
 
-  const recordBottleFeeding = useCallback(async (amount: string, unit: 'ml' | 'oz', notes?: string) => {
+  const recordBottleFeeding = useCallback(async (amount: string, unit: 'ml' | 'oz', notes?: string, timeOverride?: Date) => {
     if (!amount) return;
 
     try {
+      const now = timeOverride ?? new Date();
       if (!isAuthed) {
-        const now = new Date();
         const session: BottleFeedingSession = {
           id: Date.now().toString(),
           type: 'bottle',
@@ -210,7 +211,6 @@ export function useSessionManager(): UseSessionManagerReturn {
           return next;
         });
       } else {
-        const now = new Date();
         const url = prefixPath('/api/sessions', basePath);
         const res = await fetch(url, {
           method: 'POST',
@@ -246,19 +246,19 @@ export function useSessionManager(): UseSessionManagerReturn {
     }
   }, [basePath, isAuthed, saveLocal, mapApiToSession]);
 
-  const completeSleeping = useCallback(async (timerTimeMs: number, notes?: string) => {
+  const completeSleeping = useCallback(async (timerTimeMs: number, notes?: string, endTimeOverride?: Date) => {
     if (timerTimeMs === 0) return;
 
     try {
-      const now = new Date();
+      const endTime = endTimeOverride ?? new Date();
       const durationSeconds = Math.floor(timerTimeMs / 1000);
-      const startTime = new Date(now.getTime() - timerTimeMs);
+      const startTime = new Date(endTime.getTime() - timerTimeMs);
       if (!isAuthed) {
         const local: SleepingSession = {
           id: String(Date.now()),
           type: 'sleeping',
           startTime,
-          endTime: now,
+          endTime,
           date: startTime.toISOString().split('T')[0],
           duration: durationSeconds,
           notes: notes || undefined,
@@ -277,7 +277,7 @@ export function useSessionManager(): UseSessionManagerReturn {
           body: JSON.stringify({
             sessionType: 'sleeping',
             startTime: startTime.toISOString(),
-            endTime: now.toISOString(),
+            endTime: endTime.toISOString(),
             duration: durationSeconds,
             notes: notes || null,
           }),
@@ -370,6 +370,31 @@ export function useSessionManager(): UseSessionManagerReturn {
     }
   }, [basePath, isAuthed, saveLocal, mapApiToSession]);
 
+  const deleteSessions = useCallback(async (ids: string[]) => {
+    if (!ids.length) return;
+    try {
+      if (!isAuthed) {
+        setSessions(prev => {
+          const next = prev.filter(s => !ids.includes(s.id));
+          saveLocal(next);
+          return next;
+        });
+      } else {
+        await Promise.all(ids.map(async (id) => {
+          const url = prefixPath(`/api/sessions/${id}`, basePath);
+          const res = await fetch(url, { method: 'DELETE', credentials: 'include' });
+          if (!res.ok) throw new Error(`DELETE /api/sessions/${id} failed: ${res.status}`);
+        }));
+        setSessions(prev => prev.filter(s => !ids.includes(s.id)));
+      }
+      toast.success('Session deleted');
+    } catch (e: any) {
+      console.error('Failed to delete sessions:', e);
+      toast.error('Failed to delete sessions');
+      setError(e?.message || 'Failed to delete sessions');
+    }
+  }, [basePath, isAuthed, saveLocal]);
+
   const refreshSessions = useCallback(async () => {
     if (refreshingRef.current) return; // prevent re-entry
     try {
@@ -416,6 +441,7 @@ export function useSessionManager(): UseSessionManagerReturn {
     completeBreastfeeding,
     recordBottleFeeding,
     completeSleeping,
-    recordDiaperChange
+    recordDiaperChange,
+    deleteSessions
   };
 }


### PR DESCRIPTION
## Summary
- allow overriding session timestamps when user edits date/time and reset after saving
- add session deletion API in client and selection UI to remove history entries

## Testing
- `npm test` *(fails: TypeError: (0 , _authclient.useSession) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fe77f9288323a6da1fe8731a37d1